### PR TITLE
update ios script with armv7s,make universal library

### DIFF
--- a/ios-build.sh
+++ b/ios-build.sh
@@ -1,31 +1,70 @@
 #!/bin/bash
-#
-export DEVELOPER_ROOT_PATH=/Applications/Xcode.app/Contents/Developer
-export CC=${DEVELOPER_ROOT_PATH}/Platforms/iPhoneOS.platform/Developer/usr/bin/arm-apple-darwin10-llvm-gcc-4.2
-export SYS_ROOT=${DEVELOPER_ROOT_PATH}/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk
-function build_ffmpeg
-{
-./configure --target-os=darwin \
-	--prefix=./ios/armv7/ \
-	--enable-cross-compile \
-	--arch=arm \
-	--cpu=cortex-a8 \
-	--cc=${CC} \
-	--as="gas-preprocessor.pl ${CC}" \
-  	--disable-armv5te \
-  	--disable-armv6  \
-  	--disable-armv6t2 \
-	--disable-ffplay \
-    --disable-ffprobe \
-    --disable-ffserver \
-	--enable-neon \
-	--extra-cflags="-march=armv7-a -mfpu=neon -mfloat-abi=softfp -DUSE_HFC_LOG  -isysroot ${SYS_ROOT}" \
-	--extra-ldflags="-isysroot ${SYS_ROOT}" \
-	--disable-yasm \
-    --disable-asm
+#build ffmpeg for armv7,armv7s and uses lipo to create fat libraries and deletes the originals
 
-sed  -i '.ori' 's/CONFIGURATION.*$/CONFIGURATION \" \"/g' config.h
+
+./configure \
+--prefix=ios/armv7 \
+--disable-ffmpeg \
+--disable-ffplay \
+--disable-ffprobe \
+--disable-ffserver \
+--enable-avresample \
+--enable-cross-compile \
+--sysroot="/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk" \
+--target-os=darwin \
+--cc="/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/gcc" \
+--extra-cflags="-arch armv7 -mfpu=neon -miphoneos-version-min=6.0" \
+--extra-ldflags="-arch armv7 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk -miphoneos-version-min=6.0" \
+--arch=arm \
+--cpu=cortex-a8 \
+--enable-pic 
+
 make clean
-make  -j4 install
-}
-build_ffmpeg
+make
+make install
+
+./configure \
+--prefix=ios/armv7s \
+--disable-ffmpeg \
+--disable-ffplay \
+--disable-ffprobe \
+--disable-ffserver \
+--enable-avresample \
+--enable-cross-compile \
+--sysroot="/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk" \
+--target-os=darwin \
+--cc="/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/gcc" \
+--extra-cflags="-arch armv7s -mfpu=neon -miphoneos-version-min=6.0" \
+--extra-ldflags="-arch armv7s -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk -miphoneos-version-min=6.0" \
+--arch=arm \
+--cpu=cortex-a9 \
+--enable-pic
+
+make clean
+make
+make install
+
+cd ios
+
+mkdir -p universal/lib
+
+
+xcrun -sdk iphoneos lipo -create -arch armv7 armv7/lib/libavformat.a -arch armv7s armv7s/lib/libavformat.a -output universal/lib/libavformat
+
+xcrun -sdk iphoneos lipo -create -arch armv7 armv7/lib/libavutil.a -arch armv7s armv7s/lib/libavutil.a -output universal/lib/libavutil
+
+xcrun -sdk iphoneos lipo -create -arch armv7 armv7/lib/libswresample.a -arch armv7s armv7s/lib/libswresample.a -output universal/lib/libswresample
+
+xcrun -sdk iphoneos lipo -create -arch armv7 armv7/lib/libavcodec.a -arch armv7s armv7s/lib/libavcodec.a -output universal/lib/libavcodec
+
+xcrun -sdk iphoneos lipo -create -arch armv7 armv7/lib/libswscale.a -arch armv7s armv7s/lib/libswscale.a -output universal/lib/libswscale
+
+xcrun -sdk iphoneos lipo -create -arch armv7 armv7/lib/libavresample.a -arch armv7s armv7s/lib/libavresample.a -output universal/lib/libavresample
+
+xcrun -sdk iphoneos lipo -create -arch armv7 armv7/lib/libavdevice.a -arch armv7s armv7s/lib/libavdevice.a -output universal/lib/libavdevice
+
+xcrun -sdk iphoneos lipo -create -arch armv7 armv7/lib/libavfilter.a -arch armv7s armv7s/lib/libavfilter.a -output universal/lib/libavfilter
+
+mv armv7/include universal/include
+
+rm -rf armv7 armv7s


### PR DESCRIPTION
this rewrites the ios buildscript to make it build for both armv7 and armv7s,then uses lipo to create a fat library that holds both architectures  and deletes the originals,need to change the currently used ffmpeg library to the latest git version as this one fails to build for ios
