### PR TITLE
Buildfix for Blackberry

### DIFF
--- a/blackberry/armv7/include/libavutil/common.h
+++ b/blackberry/armv7/include/libavutil/common.h
@@ -32,11 +32,11 @@
 #if defined(BLACKBERRY) && defined(__cplusplus)
 extern "C" {
 #undef __cplusplus
-#endif
 #include <math.h>
-#if defined(BLACKBERRY) && defined(__cplusplus)
 #define __cplusplus 1
 }
+#else
+#include <math.h>
 #endif
 #include <stdio.h>
 #include <stdlib.h>

--- a/libavutil/common.h
+++ b/libavutil/common.h
@@ -32,11 +32,11 @@
 #if defined(BLACKBERRY) && defined(__cplusplus)
 extern "C" {
 #undef __cplusplus
-#endif
 #include <math.h>
-#if defined(BLACKBERRY) && defined(__cplusplus)
 #define __cplusplus 1
 }
+#else
+#include <math.h>
 #endif
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
__cplusplus won't be defined in second group of #ifdef's.
