### PR TITLE
Add: build script for armhf distributions

### DIFF
--- a/linux_armhf.sh
+++ b/linux_armhf.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -e
+
+GENERAL="\
+   --enable-cross-compile \
+   --extra-libs="-lgcc" \
+   --arch=arm \
+   --cc=arm-linux-gnueabihf-gcc \
+   --cross-prefix=arm-linux-gnueabihf- \
+   --nm=arm-linux-gnueabihf-nm"
+
+MODULES="\
+   --disable-avdevice \
+   --disable-filters \
+   --disable-programs \
+   --disable-network \
+   --disable-avfilter \
+   --disable-postproc \
+   --disable-encoders \
+   --disable-protocols \
+   --disable-hwaccels \
+   --disable-doc"
+
+VIDEO_DECODERS="\
+   --enable-decoder=h264 \
+   --enable-decoder=mpeg4 \
+   --enable-decoder=mpeg2video \
+   --enable-decoder=mjpeg \
+   --enable-decoder=mjpegb"
+
+AUDIO_DECODERS="\
+    --enable-decoder=aac \
+    --enable-decoder=aac_latm \
+    --enable-decoder=atrac3 \
+    --enable-decoder=atrac3p \
+    --enable-decoder=mp3 \
+    --enable-decoder=pcm_s16le \
+    --enable-decoder=pcm_s8"
+  
+DEMUXERS="\
+    --enable-demuxer=h264 \
+    --enable-demuxer=m4v \
+    --enable-demuxer=mpegvideo \
+    --enable-demuxer=mpegps \
+    --enable-demuxer=mp3 \
+    --enable-demuxer=avi \
+    --enable-demuxer=aac \
+    --enable-demuxer=pmp \
+    --enable-demuxer=oma \
+    --enable-demuxer=pcm_s16le \
+    --enable-demuxer=pcm_s8 \
+    --enable-demuxer=wav"
+
+VIDEO_ENCODERS="\
+    --enable-encoder=huffyuv \
+    --enable-encoder=ffv1 \
+    --enable-encoder=mjpeg"
+
+AUDIO_ENCODERS="\
+    --enable-encoder=pcm_s16le"
+
+MUXERS="\
+    --enable-muxer=avi"
+
+
+PARSERS="\
+    --enable-parser=h264 \
+    --enable-parser=mpeg4video \
+    --enable-parser=mpegaudio \
+    --enable-parser=mpegvideo \
+    --enable-parser=aac \
+    --enable-parser=aac_latm"
+
+function build_ARMv7
+{
+./configure --target-os=linux \
+    --prefix=./linux/armv7 \
+    ${GENERAL} \
+    --extra-cflags=" -O3 -fasm -Wno-psabi -fno-short-enums -fno-strict-aliasing -finline-limit=300 -mfloat-abi=hard -mfpu=neon -marm -march=armv7-a" \
+    --disable-shared \
+    --enable-static \
+    --enable-zlib \
+    --disable-everything \
+    ${MODULES} \
+    ${VIDEO_DECODERS} \
+    ${AUDIO_DECODERS} \
+    ${VIDEO_ENCODERS} \
+    ${AUDIO_ENCODERS} \
+    ${DEMUXERS} \
+    ${MUXERS} \
+    ${PARSERS}
+make clean
+make install
+}
+
+build_ARMv7
+echo Linux ARM builds finished


### PR DESCRIPTION
## Description
Add armhf build script

## Motivation and Context
There would no patches needed anymore i.e launchpad https://git.launchpad.net/~ppsspp/ppsspp/+git/debian/tree/
to build it on hard floating point systems 

## How Has This Been Tested?
Tested on ODROID-XU4