### PR TITLE
Fix compiling error with glibc 2.36

### DIFF
--- a/configure
+++ b/configure
@@ -5286,7 +5286,7 @@ check_func  ${malloc_prefix}memalign            && enable memalign
 check_func  ${malloc_prefix}posix_memalign      && enable posix_memalign
 
 check_func  access
-check_func  arc4random
+check_func_headers stdlib.h arc4random
 check_func_headers time.h clock_gettime || { check_func_headers time.h clock_gettime -lrt && add_extralibs -lrt && LIBRT="-lrt"; }
 check_func  fcntl
 check_func  fork


### PR DESCRIPTION
When compiling with glibc 2.36 on Linux, I got this error
```
gcc -I. -I./ -Wdate-time -D_FORTIFY_SOURCE=2 -D_ISOC99_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -DPIC -DZLIB_CONST -DHAVE_AV_CONFIG_H -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security  -D__STDC_CONSTANT_MACROS -O3 -std=c99 -fomit-frame-pointer -fPIC -pthread  -g -Wdeclaration-after-statement -Wall -Wdisabled-optimization -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wtype-limits -Wundef -Wmissing-prototypes -Wno-pointer-to-int-cast -Wstrict-prototypes -Wempty-body -Wno-parentheses -Wno-switch -Wno-format-zero-length -Wno-pointer-sign -Wno-unused-const-variable -O3 -fno-math-errno -fno-signed-zeros -Werror=format-security -Werror=implicit-function-declaration -Werror=missing-prototypes -Werror=return-type -Werror=vla -Wformat -fdiagnostics-color=auto -Wno-maybe-uninitialized  -MMD -MF libavutil/random_seed.d -MT libavutil/random_seed.o -c -o libavutil/random_seed.o libavutil/random_seed.c
libavutil/random_seed.c: In function ‘av_get_random_seed’:
libavutil/random_seed.c:130:12: error: implicit declaration of function ‘arc4random’; did you mean ‘srandom’? [-Werror=implicit-function-declaration]
  130 |     return arc4random();
      |            ^~~~~~~~~~
      |            srandom
cc1: some warnings being treated as errors
```
glibc 2.36 added the arc4random function https://sourceware.org/bugzilla/show_bug.cgi?id=4417, thus HAVE_ARC4RANDOM will be defined 
https://github.com/hrydgard/ppsspp-ffmpeg/blob/8fff3b3efb61b05d1eee1be35f1e99991ff5422b/configure#L5289
https://github.com/hrydgard/ppsspp-ffmpeg/blob/8fff3b3efb61b05d1eee1be35f1e99991ff5422b/libavutil/random_seed.c#L129-L131

But we didn't define the __USE_MISC macro in source code, the declaration of arc4random in stdlib.h will not be included
```
# ifdef __USE_MISC
...
/* Return a random integer between zero and 2**32-1 (inclusive).  */
extern __uint32_t arc4random (void)
     __THROW __wur;
...
# endif /* Use misc.  */
```

[Upstream has changed check_func to check_func_headers](https://github.com/FFmpeg/FFmpeg/commit/79dc94a63b30369e39792e81cb032f2cf40539b4), we can follow it to prevent using arc4random on Linux with glibc 2.36+
