### PR TITLE
Android: Remove --sysroot arg in build scripts

### DIFF
--- a/android_arm64-v8a.sh
+++ b/android_arm64-v8a.sh
@@ -92,7 +92,6 @@ function build_arm64
     --prefix=./android/arm64 \
     --arch=aarch64 \
     ${GENERAL} \
-    --sysroot=$NDK/sysroot \
     --extra-cflags=" --target=aarch64-none-linux-android21 -no-canonical-prefixes -fdata-sections -ffunction-sections -fno-limit-debug-info -funwind-tables -fPIC -O2 -DANDROID -DANDROID_PLATFORM=$BUILD_ANDROID_PLATFORM -Dipv6mr_interface=ipv6mr_ifindex -fasm -fno-short-enums -fno-strict-aliasing -Wno-missing-prototypes" \
     --disable-shared \
     --enable-static \

--- a/android_armeabi-v7a.sh
+++ b/android_armeabi-v7a.sh
@@ -91,7 +91,6 @@ function build_ARMv6
 ./configure --target-os=linux \
     --prefix=./android/armv6 \
     ${GENERAL} \
-    --sysroot=$NDK_PLATFORM \
     --extra-cflags=" --target=arm-linux-androideabi -O3 -DANDROID -fpic -fasm -fno-short-enums -fno-strict-aliasing -mfloat-abi=softfp -mfpu=vfp -marm -march=armv6" \
     --disable-shared \
     --enable-static \
@@ -117,7 +116,6 @@ function build_ARMv7
 ./configure --target-os=linux \
     --prefix=./android/armv7 \
     ${GENERAL} \
-    --sysroot=$NDK_PLATFORM \
     --extra-cflags=" --target=arm-linux-androideabi -O3 -DANDROID -fpic -fasm -fno-short-enums -fno-strict-aliasing -mfloat-abi=softfp -mfpu=vfp -marm -march=armv7-a" \
     --disable-shared \
     --enable-static \

--- a/android_x86.sh
+++ b/android_x86.sh
@@ -91,7 +91,6 @@ function build_x86
     --prefix=./android/x86 \
     --arch=x86 \
     ${GENERAL} \
-    --sysroot=$NDK_PLATFORM \
     --extra-cflags=" --target=i686-linux-android -O3 -DANDROID -Dipv6mr_interface=ipv6mr_ifindex -fasm -fno-short-enums -fno-strict-aliasing -fomit-frame-pointer -march=k8" \
     --disable-shared \
     --enable-static \

--- a/android_x86_64.sh
+++ b/android_x86_64.sh
@@ -88,7 +88,6 @@ function build_x86_64
     --prefix=./android/x86_64 \
     --arch=x86_64 \
     ${GENERAL} \
-    --sysroot=$NDK_PLATFORM \
     --extra-cflags=" --target=x86_64-linux-android -O3 -DANDROID -Dipv6mr_interface=ipv6mr_ifindex -fasm -fno-short-enums -fno-strict-aliasing -fomit-frame-pointer -march=x86-64" \
     --disable-shared \
     --enable-static \


### PR DESCRIPTION
Builds fail with it using recent NDK versions.  Built fine without in Linux.  See https://github.com/hrydgard/ppsspp/issues/9112.

-[Unknown]